### PR TITLE
fix: remove is_clockwise from all

### DIFF
--- a/python/polyshell/__init__.py
+++ b/python/polyshell/__init__.py
@@ -38,7 +38,6 @@ __all__ = [
     "reduce_polygon_eps",
     "reduce_polygon_len",
     "reduce_polygon_auto",
-    "is_clockwise",
 ]
 
 


### PR DESCRIPTION
### Description
`from polyshell import *` fails because `is_clockwise` is included in `__all__` but isn't actually available.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 