### PR TITLE
fix: add docs to [dependency-groups]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,14 +55,15 @@ readers = [
     "shapely>=2.0.7",
 ]
 
-docs = [
-    "mkdocs-material>=9.6.15",
-    "termynal>=0.13.1",
-]
-
 cli = [
     "matplotlib>=3.10.5",
     "typer>=0.17.4",
+]
+
+[dependency-groups]
+docs = [
+    "mkdocs-material>=9.6.15",
+    "termynal>=0.13.1",
 ]
 
 [tool.maturin]


### PR DESCRIPTION
### Description
The docs action builds with `uv sync --only-group docs`, which is currently failing. This adds the docs back to the [dependency-groups], with the added bonus the docs group won't be shipped as an extra on PyPI

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 