### PR TITLE
fix: expose __version__

### DIFF
--- a/python/polyshell/__init__.py
+++ b/python/polyshell/__init__.py
@@ -26,6 +26,7 @@ from enum import Enum
 from typing import Literal, overload
 
 from polyshell._polyshell import (
+    __version__,
     reduce_polygon_char,
     reduce_polygon_rdp,
     reduce_polygon_vw,
@@ -38,6 +39,7 @@ __all__ = [
     "reduce_polygon_eps",
     "reduce_polygon_len",
     "reduce_polygon_auto",
+    "__version__",
 ]
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,5 +136,7 @@ fn _polyshell(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     m.add_function(wrap_pyfunction!(is_valid, m)?)?;
 
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+
     Ok(())
 }


### PR DESCRIPTION
### Description
Close #20. For now just exposes the Cargo version to Python, so the version in the Cargo is the only version but it's manual and not derived from git tags

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 